### PR TITLE
FIX: try git checkout $VERSION before git checkout -b $VERSION master

### DIFF
--- a/rever/activities/conda_forge.xsh
+++ b/rever/activities/conda_forge.xsh
@@ -162,7 +162,7 @@ class CondaForge(Activity):
             git pull @(upstream) master
             # make and modify version branch
             with ${...}.swap(RAISE_SUBPROC_ERROR=False):
-                git checkout -b $VERSION master or git checkout $VERSION
+                git checkout $VERSION or git checkout -b $VERSION master
         # now, update the feedstock to the new version
         source_url = eval_version(source_url)
         hash = hash_url(source_url)


### PR DESCRIPTION
The idea here is that when you git clone a repo, there will only be a master branch locally, so `git checkout -b $VERSION master` will not fail. If there is a $VERSION branch on origin, though, `git checkout $VERSION` will create a local branch that tracks the $VERSION branch on origin. If origin has no $VERSION branch, `git checkout $VERSION` will fail and `git checkout -b $VERSION master` will run instead, creating a new branch.