### PR TITLE
ENH: use rever's tarball for the GitHub url for conda-forge

### DIFF
--- a/news/use_own_tarball.rst
+++ b/news/use_own_tarball.rst
@@ -1,0 +1,13 @@
+**Added:** None
+
+**Changed:**
+
+* Use the tarball rever generates for the conda forge URL
+
+**Deprecated:** None
+
+**Removed:** None
+
+**Fixed:** None
+
+**Security:** None

--- a/rever/activities/conda_forge.xsh
+++ b/rever/activities/conda_forge.xsh
@@ -133,9 +133,14 @@ class CondaForge(Activity):
               fork_org=''):
         if source_url is None:
             version_tag = ${...}.get('TAG_TEMPLATE', '$VERSION')
-            source_url=('https://github.com/$GITHUB_ORG/$GITHUB_REPO/releases/'
-                        'download/{}/{}.tar.gz'.format(version_tag, 
-                                                       version_tag))
+            if version_tag + '.tar.gz' in os.listdir($REVER_DIR):
+                source_url=('https://github.com/$GITHUB_ORG/$GITHUB_REPO'
+                            '/releases/download/{}/'
+                            '{}.tar.gz'.format(version_tag, version_tag))
+            else:
+                source_url = ('https://github.com/$GITHUB_ORG/$GITHUB_REPO/'
+                              'archive/{}.tar.gz'.format(version_tag))
+
         # first, let's grab the feedstock locally
         gh, username = github.login(return_username=True)
         upstream = feedstock_url(feedstock, protocol=protocol)

--- a/rever/activities/conda_forge.xsh
+++ b/rever/activities/conda_forge.xsh
@@ -134,7 +134,7 @@ class CondaForge(Activity):
         if source_url is None:
             version_tag = ${...}.get('TAG_TEMPLATE', '$VERSION')
             source_url=('https://github.com/$GITHUB_ORG/$GITHUB_REPO/download/'
-                        '{}/{}.tar.gz'.format(version_tag))
+                        '{}/{}.tar.gz'.format(version_tag, version_tag))
         # first, let's grab the feedstock locally
         gh, username = github.login(return_username=True)
         upstream = feedstock_url(feedstock, protocol=protocol)

--- a/rever/activities/conda_forge.xsh
+++ b/rever/activities/conda_forge.xsh
@@ -133,8 +133,9 @@ class CondaForge(Activity):
               fork_org=''):
         if source_url is None:
             version_tag = ${...}.get('TAG_TEMPLATE', '$VERSION')
-            source_url=('https://github.com/$GITHUB_ORG/$GITHUB_REPO/download/'
-                        '{}/{}.tar.gz'.format(version_tag, version_tag))
+            source_url=('https://github.com/$GITHUB_ORG/$GITHUB_REPO/releases/'
+                        'download/{}/{}.tar.gz'.format(version_tag, 
+                                                       version_tag))
         # first, let's grab the feedstock locally
         gh, username = github.login(return_username=True)
         upstream = feedstock_url(feedstock, protocol=protocol)

--- a/rever/activities/conda_forge.xsh
+++ b/rever/activities/conda_forge.xsh
@@ -133,8 +133,8 @@ class CondaForge(Activity):
               fork_org=''):
         if source_url is None:
             version_tag = ${...}.get('TAG_TEMPLATE', '$VERSION')
-            source_url=('https://github.com/$GITHUB_ORG/$GITHUB_REPO/archive/'
-                        '{}.tar.gz'.format(version_tag))
+            source_url=('https://github.com/$GITHUB_ORG/$GITHUB_REPO/download/'
+                        '{}/{}.tar.gz'.format(version_tag))
         # first, let's grab the feedstock locally
         gh, username = github.login(return_username=True)
         upstream = feedstock_url(feedstock, protocol=protocol)


### PR DESCRIPTION
closes #137 