### PR TITLE
Allow empty commits (when no files change)

### DIFF
--- a/news/empty-commit.rst
+++ b/news/empty-commit.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* Allow empty commits for git.  Authorship update commit was failing because no file changes were made by that update.
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/rever/vcsutils.xsh
+++ b/rever/vcsutils.xsh
@@ -123,7 +123,7 @@ track = make_vcs_dispatcher(TRACK, name='track',
 
 def git_commit(message="Rever commit"):
     """Commits to the repo."""
-    git commit -am @(message)
+    git commit --allow-empty -am @(message)
 
 
 COMMIT = {'git': git_commit}


### PR DESCRIPTION
authorship updating was failing to commit for me.  It was because there were no changed files relative to the last commit.  This change allowed my rever job to succeed.