### PR TITLE
Add repo name to archive

### DIFF
--- a/news/include-repo-name-in-artifact
+++ b/news/include-repo-name-in-artifact
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* github artifact tarball changed to include repo name in filename.  This is nicer both on disk and makes tools like versioneer work better.
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/rever/activities/conda_forge.xsh
+++ b/rever/activities/conda_forge.xsh
@@ -143,7 +143,7 @@ class CondaForge(Activity):
               fork_org=''):
         if source_url is None:
             version_tag = ${...}.get('TAG_TEMPLATE', $VERSION)
-            if version_tag + '.tar.gz' in os.listdir($REVER_DIR):
+            if $GITHUB_REPO + '-' + version_tag + '.tar.gz' in os.listdir($REVER_DIR):
                 source_url=('https://github.com/$GITHUB_ORG/$GITHUB_REPO'
                             '/releases/download/{}/'
                             '{}.tar.gz'.format(version_tag, version_tag))

--- a/rever/activities/conda_forge.xsh
+++ b/rever/activities/conda_forge.xsh
@@ -143,10 +143,11 @@ class CondaForge(Activity):
               fork_org=''):
         if source_url is None:
             version_tag = ${...}.get('TAG_TEMPLATE', $VERSION)
-            if $GITHUB_REPO + '-' + version_tag + '.tar.gz' in os.listdir($REVER_DIR):
+            release_fn = $GITHUB_REPO + '-' + version_tag + '.tar.gz'
+            if release_fn in os.listdir($REVER_DIR):
                 source_url=('https://github.com/$GITHUB_ORG/$GITHUB_REPO'
-                            '/releases/download/{}/'
-                            '{}.tar.gz'.format(version_tag, version_tag))
+                            '/releases/download/{}/{}'.format(
+                            version_tag, release_fn))
             else:
                 source_url = ('https://github.com/$GITHUB_ORG/$GITHUB_REPO/'
                               'archive/{}.tar.gz'.format(version_tag))

--- a/rever/activities/ghrelease.xsh
+++ b/rever/activities/ghrelease.xsh
@@ -37,9 +37,10 @@ def git_archive_asset():
     """Provides tarball of the repository as an asset."""
     template = ${...}.get('TAG_TEMPLATE', '$VERSION')
     tag = eval_version(template)
-    fname = os.path.join($REVER_DIR, tag + '.tar.gz')
+    folder_name = $GITHUB_REPO + '-' + tag
+    fname = os.path.join($REVER_DIR, folder_name + '.tar.gz')
     print_color('Archiving repository as {INTENSE_CYAN}' + fname + '{NO_COLOR}')
-    ![git archive -9 --format=tar.gz -o @(fname) @(tag)]
+    ![git archive -9 --format=tar.gz --prefix=@(folder_name)/ -o @(fname) @(tag)]
     return fname
 
 

--- a/rever/docker.xsh
+++ b/rever/docker.xsh
@@ -78,7 +78,6 @@ def conda_deps(conda=None, conda_channels=None):
     if channels:
         for channel in channels[::-1]:
             s += '    conda config --add channels ' + channel + ' && \\\n'
-    s += '    conda update --all --update-deps && \\\n'
     s += '    conda update --all && \\\n'
     s += '    conda install \\\n'
     s += wrap(' '.join(sorted(conda)), indent=' '*8) + ' && \\\n'

--- a/tests/test_docker.py
+++ b/tests/test_docker.py
@@ -57,7 +57,6 @@ def test_apt_deps(dockerenv, deps, exp):
     ([], ['conda-forge'], ''),
     (['dep1', 'dep0'], [],
 """RUN conda config --set always_yes yes && \\
-    conda update --all --update-deps && \\
     conda update --all && \\
     conda install \\
         dep0 dep1 && \\
@@ -69,7 +68,6 @@ def test_apt_deps(dockerenv, deps, exp):
 """RUN conda config --set always_yes yes && \\
     conda config --add channels my-channel && \\
     conda config --add channels conda-forge && \\
-    conda update --all --update-deps && \\
     conda update --all && \\
     conda install \\
         dep0 dep1 && \\
@@ -137,7 +135,6 @@ RUN apt-get -y update && \\
 RUN conda config --set always_yes yes && \\
     conda config --add channels my-channel && \\
     conda config --add channels conda-forge && \\
-    conda update --all --update-deps && \\
     conda update --all && \\
     conda install \\
         dep0 dep1 && \\


### PR DESCRIPTION
The past several releases of conda-package handling show their version as "unknown" because versioneer didn't work when the extracted folder name was just "$version".  I think I probably could fix versioneer with the setup.cfg parameters, but I also think adding the project name to the tarball is generally a good thing, as it makes it easier to look at stuff on disk.  Plain version numbers are pretty inscrutable.

This also removes some conda update --update-deps --all calls, because those two are mutually exclusive (--all implies --update-deps).  This broke in my testing of the other change because the docker image was rebuilt, and a newer conda version may have been brought in.