### PR TITLE
rever requires xonsh & lazyasd

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ def main():
         package_data={'rever': ['*.xsh'], 'rever.activities': ['*.xsh']},
         scripts=scripts,
         zip_safe=False,
-        install_requires=['xonsh', 'lazyasd'],
+        install_requires=['xonsh', 'lazyasd', 'ruamel.yaml', 'github3.py'],
         )
     # WARNING!!! Do not use setuptools 'console_scripts'
     # It validates the depenendcies everytime the

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ def main():
         package_data={'rever': ['*.xsh'], 'rever.activities': ['*.xsh']},
         scripts=scripts,
         zip_safe=False,
-        install_requires=['xonsh'],
+        install_requires=['xonsh', 'lazyasd'],
         )
     # WARNING!!! Do not use setuptools 'console_scripts'
     # It validates the depenendcies everytime the

--- a/setup.py
+++ b/setup.py
@@ -34,9 +34,10 @@ def main():
         package_data={'rever': ['*.xsh'], 'rever.activities': ['*.xsh']},
         scripts=scripts,
         zip_safe=False,
+        install_requires=['xonsh'],
         )
     # WARNING!!! Do not use setuptools 'console_scripts'
-    # It validates the depenendcies (of which we have none) everytime the
+    # It validates the depenendcies everytime the
     # 'rever' command is run. This validation adds ~0.2 sec. to the startup
     # time of xonsh - for every single xonsh run.  This prevents us from
     # reaching the goal of a startup time of < 0.1 sec.  So never ever write


### PR DESCRIPTION
So declare the dependencies in setup.py.

Also, regarding the comment about `console_scripts`: it's fine if you install with pip (`pip install .` to install locally). It only does the problematic setuptools thing if setuptools does the installation without pip supervising.