### PR TITLE
Fix UnboundLocalError

### DIFF
--- a/news/unboundlocalerror-gh3.rst
+++ b/news/unboundlocalerror-gh3.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* Fixed an UnboundLocalError when the github3 library can't be imported.
+
+**Security:**
+
+* <news item>

--- a/rever/github.xsh
+++ b/rever/github.xsh
@@ -47,7 +47,7 @@ def github3():
     try:
         from github3.github import GitHub
     except ImportError:
-        gh3 = None
+        return None
     return GitHub()
 
 


### PR DESCRIPTION
If github3.py can't be imported, this code was failing with:

```
Traceback (most recent call last):
  File "/home/takluyver/.local/lib/python3.10/site-packages/rever/activity.xsh", line 83, in __call__
    self.func(*args, **kwargs)
  File "/home/takluyver/.local/lib/python3.10/site-packages/rever/activities/ghrelease.xsh", line 101, in _func
    gh = github.login()
  File "/home/takluyver/.local/lib/python3.10/site-packages/rever/github.xsh", line 288, in login
    github3.login(username, token=token)
  File "/home/takluyver/.local/lib/python3.10/site-packages/lazyasd.py", line 64, in __getattribute__
    obj = self._lazy_obj()
  File "/home/takluyver/.local/lib/python3.10/site-packages/lazyasd.py", line 56, in _lazy_obj
    obj = d['load']()
  File "/home/takluyver/.local/lib/python3.10/site-packages/rever/github.xsh", line 51, in github3
    return GitHub()
UnboundLocalError: local variable 'GitHub' referenced before assignment
```

It looks like the local variable was previously called `gh3`.