### PR TITLE
update num_commits to account for multiple aliases per email

### DIFF
--- a/news/265-single-count-aliases.rst
+++ b/news/265-single-count-aliases.rst
@@ -1,0 +1,24 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* Don't double-count contributions when users have multiple aliases per e-mail.
+  (#265)
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/rever/authors.xsh
+++ b/rever/authors.xsh
@@ -301,7 +301,9 @@ def update_metadata(filename, write=True, validation_error=True):
     cpe = vcsutils.commits_per_email()
     fcpe = None
     for x in y:
-        x["num_commits"] = cpe.get(x["email"], 0) + sum([cpe.get(a, 0) for a in x.get("alternate_emails", [])])
+        # if duplicate nicknames A <foo@example>, A B <foo@example>
+        unique_emails = set([x["email"]] + x.get("alternate_emails", []))
+        x["num_commits"] = sum([cpe.get(a, 0) for a in unique_emails])
         # only compute first commits if needed.
         if "first_commit" not in x:
             if fcpe is None:


### PR DESCRIPTION
Rever counted contributions twice in a mailmap like this one https://github.com/conda/conda-package-handling/blob/main/.mailmap#L41

Fix by using `set(email addressses)` to count contributions.

Fixes #265 