### PR TITLE
bugfix: Fix git shortlog returning no output in non-TTY environments

### DIFF
--- a/rever/vcsutils.xsh
+++ b/rever/vcsutils.xsh
@@ -231,6 +231,8 @@ def git_commits_per_author(since=None):
     args = ['-s', '-e', '--no-merges']
     if since:
         args.append(since + "...HEAD")
+    else:
+        args.append("HEAD")
     for line in $(git shortlog @(args)).splitlines():
         m = RE_GIT_CPA.match(line)
         if m is None:
@@ -259,6 +261,8 @@ def git_commits_per_email(since=None):
     args = ['-s', '-e', '--no-merges']
     if since:
         args.append(since + "...HEAD")
+    else:
+        args.append("HEAD")
     for line in $(git shortlog @(args)).splitlines():
         n, email = RE_GIT_CPE.match(line).groups()
         cpe[email] = int(n)

--- a/tests/test_vcsutils.py
+++ b/tests/test_vcsutils.py
@@ -1,0 +1,67 @@
+"""Tests for rever.vcsutils."""
+import os
+import subprocess
+
+import pytest
+
+from rever import environ, vcsutils
+
+
+def _make_commit(path, filename, message, author_name, author_email):
+    """Write a file and commit it in the given directory."""
+    filepath = os.path.join(path, filename)
+    with open(filepath, "w") as f:
+        f.write(message)
+    env = {
+        **os.environ,
+        "GIT_AUTHOR_NAME": author_name,
+        "GIT_AUTHOR_EMAIL": author_email,
+        "GIT_COMMITTER_NAME": author_name,
+        "GIT_COMMITTER_EMAIL": author_email,
+    }
+    subprocess.run(["git", "add", filepath], check=True)
+    subprocess.run(["git", "commit", "-m", message], check=True, env=env)
+
+
+@pytest.fixture
+def two_author_repo(gitrepo):
+    """Extend the base gitrepo with commits from two distinct authors."""
+    _make_commit(gitrepo, "a1.txt", "alice commit 1", "Alice", "alice@example.com")
+    _make_commit(gitrepo, "a2.txt", "alice commit 2", "Alice", "alice@example.com")
+    _make_commit(gitrepo, "b1.txt", "bob commit 1", "Bob", "bob@example.com")
+    yield gitrepo
+
+
+def test_commits_per_email_without_tty(two_author_repo):
+    """git_commits_per_email must return correct counts when stdin is not a TTY.
+
+    Regression test: ``git shortlog`` without an explicit revision reads from
+    stdin. In non-interactive environments (CI, subprocess, agent runners)
+    stdin is empty/closed, so shortlog exits immediately and every author gets
+    0 commits. The fix is to always pass HEAD when no ``since`` boundary is
+    given.
+    """
+    cpe = vcsutils.commits_per_email()
+    assert cpe.get("alice@example.com") == 2, cpe
+    assert cpe.get("bob@example.com") == 1, cpe
+
+
+def test_commits_per_author_without_tty(two_author_repo):
+    """git_commits_per_author must return correct counts when stdin is not a TTY.
+
+    Same root cause as test_commits_per_email_without_tty — both functions
+    share the same ``git shortlog`` pattern.
+    """
+    cpa = vcsutils.commits_per_author()
+    assert cpa.get("Alice <alice@example.com>") == 2, cpa
+    assert cpa.get("Bob <bob@example.com>") == 1, cpa
+
+
+def test_commits_per_email_with_since(two_author_repo):
+    """When a ``since`` tag is given the range X...HEAD form is still used."""
+    vcsutils.tag("v0")
+    _make_commit(two_author_repo, "a3.txt", "alice commit 3", "Alice", "alice@example.com")
+
+    cpe = vcsutils.commits_per_email(since="v0")
+    assert cpe.get("alice@example.com") == 1, cpe
+    assert "bob@example.com" not in cpe, cpe


### PR DESCRIPTION
### Introduction

Hi maintainers 👋,

This is my first contribution to this repository, so if I have not done anything correctly, please excuse me and just let me know what to do.

I found this bug while releasing [conda 26.5.0](https://github.com/conda/conda/issues/15984). I specifically found it because I was using rever in an [opencode](https://opencode.ai/) session where it was in a non-TTY environment.

The bug fix submitted was something that my LLM (Claude Opus 4.6) suggested to me, and I have gone even further by including regression tests that we're also written by the LLM.

Please let me know if these change are acceptable and what I can do to improve them if they are not.

Thanks! 

### Full description of changes

`git shortlog` without an explicit revision reads from stdin. In non-interactive environments (CI, subprocess calls, agent runners) stdin is empty/closed, so it exits immediately with no output. This caused `git_commits_per_author` and `git_commits_per_email` to return empty dicts, silently setting every author's `num_commits` to 0.

Fix by appending `HEAD` to the args when no `since` boundary is given, so `git shortlog` always traverses the full commit history regardless of whether stdin is a terminal. The same bug exists in both `git_commits_per_author` and `git_commits_per_email` since they share the same pattern.